### PR TITLE
refactor: load env vars from host

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ The servers are configured in `mcp.json` and can be started via an MCP-compatibl
 node packages/servers/contentops/dist/index.js
 node packages/servers/devworkflow/dist/index.js
 ```
+
+### Environment variables
+
+Copy `.env.example` to `.env` and fill in the required values. The `mcp.json` file references these values using the `env:` prefix so that secrets are loaded from your local environment and are not committed to source control.

--- a/mcp.json
+++ b/mcp.json
@@ -6,11 +6,11 @@
         "packages/servers/contentops/dist/index.js"
       ],
       "env": {
-        "SANITY_PROJECT_ID": "xxxx",
-        "SANITY_DATASET": "production",
+        "SANITY_PROJECT_ID": "env:SANITY_PROJECT_ID",
+        "SANITY_DATASET": "env:SANITY_DATASET",
         "SANITY_TOKEN": "env:SANITY_TOKEN",
         "NEXT_REVALIDATE_SECRET": "env:NEXT_REVALIDATE_SECRET",
-        "NEXT_REVALIDATE_URL": "https://growthstats.io/api/revalidate"
+        "NEXT_REVALIDATE_URL": "env:NEXT_REVALIDATE_URL"
       }
     },
     "growthstats-devworkflow": {
@@ -19,7 +19,7 @@
         "packages/servers/devworkflow/dist/index.js"
       ],
       "env": {
-        "REPO_PATH": "/absolute/path/to/your/growthstats-app",
+        "REPO_PATH": "env:REPO_PATH",
         "GITHUB_TOKEN": "env:GITHUB_TOKEN"
       }
     }


### PR DESCRIPTION
## Summary
- replace hard-coded values in `mcp.json` with `env:` references so secrets load from local env
- document `.env` setup for MCP servers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a972ec7828832886e85e07a7b6b074